### PR TITLE
Pin pytest<5.4 for a temporary bug fix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
 
 [options.extras_require]
 tests =
-  pytest
+  pytest < 5.4
   pytest-doctestplus >= 0.5 # We require the newest version of doctest plus to use +IGNORE_WARNINGS
   pytest-astropy >= 0.8  # 0.8 is the first release to include filter-subpackage
   pytest-cov


### PR DESCRIPTION
This is to fix a bug that is due to pytest 5.4.1 and xdist. Follow-up on code review of https://github.com/sunpy/sunraster/pull/139.