### PR TITLE
Fix doc bugs in "remove iris_code" branch

### DIFF
--- a/changelog/139.breaking.rst
+++ b/changelog/139.breaking.rst
@@ -1,1 +1,1 @@
-Make RasterSequence aware of instrument axis types.
+

--- a/changelog/139.breaking.rst
+++ b/changelog/139.breaking.rst
@@ -1,6 +1,1 @@
-Make RasterSequence aware of instrument axis types. This is in addition to
-``world_axis_physical_types``, which gives the real world coordinates of the axes. In contrast,
-these new axis types define the axes as ``raster scan``, ``slit step``, ``position along slit`` and ``spectral``.
-This information will update as the RasterSequence as it is sliced etc. This also breaks
-`~sunraster.raster_sequence.RasterSequence` out into its own module, like ``NDCubeSequence``
-as the lines of code are now enough to justify that.
+Make RasterSequence aware of instrument axis types.

--- a/docs/data_classes.rst
+++ b/docs/data_classes.rst
@@ -405,7 +405,6 @@ We can now define our `~sunraster.RasterSequence` by doing:
 
   >>> from sunraster import RasterSequence
   >>> my_sequence = RasterSequence([raster0, raster1, raster2], meta=seq_meta, common_axis=0)
-  ['slit step' None 'spectral']
 
 Dimensions
 ^^^^^^^^^^

--- a/docs/data_classes.rst
+++ b/docs/data_classes.rst
@@ -260,6 +260,7 @@ for more.
   >>> extra_coords_input = [("exposure time", 0, exposure_times)]
   >>> my_raster = Raster(data, input_wcs, uncertainty=np.sqrt(data), mask=mask,
   ...                    meta=meta, unit=u.ct, extra_coords=extra_coords_input)
+  INFO: uncertainty should have attribute uncertainty_type. [astropy.nddata.nddata]
 
 To apply the exposure time correction simply do:
 
@@ -269,6 +270,7 @@ To apply the exposure time correction simply do:
   >>> print(my_raster.unit, my_raster.data.mean())
   ct 1.0
   >>> my_raster = my_raster.apply_exposure_time_correction() # Apply exposure time correction.
+  INFO: uncertainty should have attribute uncertainty_type. [astropy.nddata.nddata]
   >>> # Check data unit and average data value again.
   >>> print(my_raster.unit, my_raster.data.mean())
   ct / s 2.0
@@ -288,17 +290,20 @@ the ``force`` kwarg to override the check.
   >>> print(my_raster.unit, my_raster.data.mean())
   ct / s 2.0
   >>> my_raster = my_raster.apply_exposure_time_correction(force=True)
+  INFO: uncertainty should have attribute uncertainty_type. [astropy.nddata.nddata]
   >>> print(my_raster.unit, my_raster.data.mean())
-  ct / s / s 4.0
+  ct / s2 4.0
 
 Should users like to undo the correction, they can set the ``undo`` kwarg.
 
 .. code-block:: python
 
   >>> print(my_raster.unit, my_raster.data.mean())
-  ct / s / s 4.0
-  >>> my_raster = my_raster.apply_exposure_time_correction(undo=True)
+  ct / s2 4.0
+  >>> my_raster = my_raster.apply_exposure_time_correction(undo=True, force=True)
+  INFO: uncertainty should have attribute uncertainty_type. [astropy.nddata.nddata]
   >>> my_raster = my_raster.apply_exposure_time_correction(undo=True) # Undo correction twice.
+  INFO: uncertainty should have attribute uncertainty_type. [astropy.nddata.nddata]
   >>> print(my_raster.unit, my_raster.data.mean())
   ct 1.0
 
@@ -310,7 +315,8 @@ Again as before, users can override this check by setting the ``force`` kwarg.
 
   >>> print(my_raster.unit, my_raster.data.mean())
   ct 1.0
-  my_raster = my_raster.apply_exposure_time_correction(undo=True, force=True)
+  >>> my_raster = my_raster.apply_exposure_time_correction(undo=True, force=True)
+  INFO: uncertainty should have attribute uncertainty_type. [astropy.nddata.nddata]
   >>> print(my_raster.unit, my_raster.data.mean())
   ct s 0.5
 
@@ -360,6 +366,7 @@ timestamps and exposure times as extra coordinates.
   >>> extra_coords_input0 = [("time", 0, timestamps0), ("exposure time", 0, exposure_times)]
   >>> raster0 = Raster(data, input_wcs, uncertainty=np.sqrt(data), mask=mask,
   ...                  meta=meta, unit=u.ct, extra_coords=extra_coords_input0)
+  INFO: uncertainty should have attribute uncertainty_type. [astropy.nddata.nddata]
 
   >>> # Create 2nd raster
   >>> timestamps1 = Time([timestamps0[-1].to_datetime() + timedelta(minutes=i)
@@ -367,6 +374,7 @@ timestamps and exposure times as extra coordinates.
   >>> extra_coords_input1 = [("time", 0, timestamps1), ("exposure time", 0, exposure_times)]
   >>> raster1 = Raster(data*2, input_wcs, uncertainty=np.sqrt(data), mask=mask,
   ...                  meta=meta, unit=u.ct, extra_coords=extra_coords_input1)
+  INFO: uncertainty should have attribute uncertainty_type. [astropy.nddata.nddata]
 
   >>> # Create 3rd raster
   >>> timestamps2 = Time([timestamps1[-1].to_datetime() + timedelta(minutes=i)
@@ -374,6 +382,7 @@ timestamps and exposure times as extra coordinates.
   >>> extra_coords_input2 = [("time", 0, timestamps2), ("exposure time", 0, exposure_times)]
   >>> raster2 = Raster(data*0.5, input_wcs, uncertainty=np.sqrt(data), mask=mask,
   ...                  meta=meta, unit=u.ct, extra_coords=extra_coords_input2)
+  INFO: uncertainty should have attribute uncertainty_type. [astropy.nddata.nddata]
 
 If we choose, we can define some sequence-level metadata in addition to any
 metadata attached to the individual raster scans:
@@ -395,7 +404,8 @@ We can now define our `~sunraster.RasterSequence` by doing:
 .. code-block:: python
 
   >>> from sunraster import RasterSequence
-  >>> my_sequence = RasterSequence([raster0, raster1, raster2], meta=seq_meta, slit_step_axis=0)
+  >>> my_sequence = RasterSequence([raster0, raster1, raster2], meta=seq_meta, common_axis=0)
+  ['slit step' None 'spectral']
 
 Dimensions
 ^^^^^^^^^^
@@ -546,7 +556,7 @@ the following:
   >>> print(my_sequence_roi.raster_dimensions) # See how slicing has changed dimensionality.
   (<Quantity 2. pix>, <Quantity 2. pix>, <Quantity 2. pix>, <Quantity 3. pix>)
   >>> my_sequence_roi.SnS_dimensions  # Dimensionality can still be represented in SnS form.
-  [4., 2., 3.] pix
+  <Quantity [4., 2., 3.] pix>
 
 To slice in the sit-and-stare representation, do the following:
 
@@ -558,7 +568,7 @@ To slice in the sit-and-stare representation, do the following:
   >>> my_sequence_roi = my_sequence.slice_as_SnS[1:7, 1:3, 1:4]
 
   >>> print(my_sequence_roi.SnS_dimensions)  # See how slicing has changed dimensionality.
-  [6., 2., 3.] pix
+  [6. 2. 3.] pix
   >>> print(my_sequence_roi.raster_dimensions)  # Dimensionality can still be represented in raster form.
   (<Quantity 3. pix>, <Quantity [2., 3., 1.] pix>, <Quantity 2. pix>, <Quantity 3. pix>)
 

--- a/sunraster/utils/sequence.py
+++ b/sunraster/utils/sequence.py
@@ -46,8 +46,8 @@ def _slice_sequence_as_SnS(sequence, item):
     ...                             (slice(0, cubeB.shape[2])) # doctest: +SKIP
     """
     # Convert item to a list of single Raster items for each relevant raster.
-    n_slit_steps = np.array([c.data.shape[sequence._slit_step_axis] for c in sequence.data])
-    sequence_items = convert_SnS_item_to_sequence_items(item, sequence._slit_step_axis,
+    n_slit_steps = np.array([c.data.shape[sequence._common_axis] for c in sequence.data])
+    sequence_items = convert_SnS_item_to_sequence_items(item, sequence._common_axis,
                                                         n_slit_steps)
     # Use sequence items to slice NDCubeSequence.
     return ndcube.utils.sequence.slice_sequence_by_sequence_items(sequence, sequence_items)


### PR DESCRIPTION
Have made basic changes to RST docs in the `remove_iris_code` branch of `sunraster` to pass the `tox` docs tests, with results on local machine as follows. 
```
collected 26 items                                                                                                                                                                 

../../.tox/py37/lib/python3.7/site-packages/sunraster/tests/test_raster.py::test_apply_exposure_time_correction[input_cube0-False-False-expected_cube0] PASSED               [  3%]
../../.tox/py37/lib/python3.7/site-packages/sunraster/tests/test_raster.py::test_apply_exposure_time_correction[input_cube1-True-False-expected_cube1] PASSED                [  7%]
../../.tox/py37/lib/python3.7/site-packages/sunraster/tests/test_raster.py::test_apply_exposure_time_correction[input_cube2-False-True-expected_cube2] PASSED                [ 11%]
../../.tox/py37/lib/python3.7/site-packages/sunraster/tests/test_raster.py::test_apply_exposure_time_correction[input_cube3-True-True-expected_cube3] PASSED                 [ 15%]
../../.tox/py37/lib/python3.7/site-packages/sunraster/tests/test_rastersequence.py::test_apply_exposure_time_correction[input_sequence0-False-False-expected_sequence0] PASSED [ 19%]
../../.tox/py37/lib/python3.7/site-packages/sunraster/tests/test_rastersequence.py::test_apply_exposure_time_correction[input_sequence1-True-False-expected_sequence1] PASSED [ 23%]
../../.tox/py37/lib/python3.7/site-packages/sunraster/tests/test_rastersequence.py::test_apply_exposure_time_correction[input_sequence2-False-True-expected_sequence2] PASSED [ 26%]
../../.tox/py37/lib/python3.7/site-packages/sunraster/tests/test_rastersequence.py::test_apply_exposure_time_correction[input_sequence3-True-True-expected_sequence3] PASSED [ 30%]
../../.tox/py37/lib/python3.7/site-packages/sunraster/tests/test_rastersequence.py::test_raster_instrument_axes_types[input_sequence0-expected_raster_axes_types0] PASSED    [ 34%]
../../.tox/py37/lib/python3.7/site-packages/sunraster/tests/test_rastersequence.py::test_raster_instrument_axes_types[input_sequence1-expected_raster_axes_types1] PASSED    [ 38%]
../../.tox/py37/lib/python3.7/site-packages/sunraster/tests/test_rastersequence.py::test_raster_instrument_axes_types[input_sequence2-expected_raster_axes_types2] PASSED    [ 42%]
../../.tox/py37/lib/python3.7/site-packages/sunraster/tests/test_rastersequence.py::test_raster_instrument_axes_types[input_sequence3-expected_raster_axes_types3] PASSED    [ 46%]
../../.tox/py37/lib/python3.7/site-packages/sunraster/tests/test_rastersequence.py::test_raster_instrument_axes_types[input_sequence4-expected_raster_axes_types4] PASSED    [ 50%]
../../.tox/py37/lib/python3.7/site-packages/sunraster/tests/test_rastersequence.py::test_raster_instrument_axes_types[input_sequence5-expected_raster_axes_types5] PASSED    [ 53%]
../../.tox/py37/lib/python3.7/site-packages/sunraster/tests/test_rastersequence.py::test_SnS_instrument_axes_types[input_sequence0-expected_SnS_axes_types0] PASSED          [ 57%]
../../.tox/py37/lib/python3.7/site-packages/sunraster/tests/test_rastersequence.py::test_SnS_instrument_axes_types[input_sequence1-expected_SnS_axes_types1] PASSED          [ 61%]
../../.tox/py37/lib/python3.7/site-packages/sunraster/utils/sequence.py::sunraster.utils.sequence._slice_sequence_as_SnS SKIPPED                                             [ 65%]
../../docs/api.rst PASSED                                                                                                                                                    [ 69%]
../../docs/contributing.rst PASSED                                                                                                                                           [ 73%]
../../docs/data_classes.rst PASSED                                                                                                                                           [ 76%]
../../docs/getting_help.rst PASSED                                                                                                                                           [ 80%]
../../docs/index.rst PASSED                                                                                                                                                  [ 84%]
../../docs/installation.rst PASSED                                                                                                                                           [ 88%]
../../docs/introduction.rst PASSED                                                                                                                                           [ 92%]
../../docs/whatsnew/changelog.rst PASSED                                                                                                                                     [ 96%]
../../docs/whatsnew/index.rst PASSED                                                                                                                                         [100%]



========================================================================== 25 passed, 1 skipped in 1.20s ===========================================================================
```